### PR TITLE
Fixed an issue where the SDK cannot authorize with Podcaster.de because it did not specify a scope.

### DIFF
--- a/src/Podcaster/PodcasterAuthClient.php
+++ b/src/Podcaster/PodcasterAuthClient.php
@@ -36,6 +36,7 @@ class PodcasterAuthClient
         $this->provider = new \League\OAuth2\Client\Provider\GenericProvider([
             'clientId'                => $clientId,
             'clientSecret'            => $clientSecret,
+            'scopes'                  => array('*'),
             'redirectUri'             => $redirectUri,
             'urlAuthorize'            => $apiUrl . self::AUTHORIZE_URI,
             'urlAccessToken'          => $apiUrl . self::ACCESSTOKEN_URI,


### PR DESCRIPTION
Fixes an issue where the SDK cannot authorize with Podcaster.de because it did not specify a scope by adding a wildcard scope to the OAuth provider.